### PR TITLE
Fix mac homelab external drive setup

### DIFF
--- a/.env.mac
+++ b/.env.mac
@@ -1,0 +1,59 @@
+# Mac Homelab Environment Variables
+# Copy this to .env and fill in your values
+
+# ===================================================================
+# CLOUDFLARE DNS CHALLENGE (Required for SSL certificates)
+# ===================================================================
+CF_API_EMAIL=your-email@example.com
+CF_DNS_API_TOKEN=your-cloudflare-api-token-here
+
+# ===================================================================
+# DATABASE PASSWORDS
+# ===================================================================
+NEXTCLOUD_DB_PASSWORD=nextcloud-secure-password-2024-CHANGE-ME
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=admin-secure-password-2024-CHANGE-ME
+
+# ===================================================================
+# AUTHELIA SECURITY (CRITICAL - CHANGE THESE)
+# ===================================================================
+AUTHELIA_SESSION_SECRET=CHANGE-ME-generate-secure-32-char-string
+AUTHELIA_STORAGE_ENCRYPTION_KEY=CHANGE-ME-generate-secure-32-char-string
+AUTHELIA_JWT_SECRET=CHANGE-ME-generate-secure-32-char-string
+
+# ===================================================================
+# VAULTWARDEN ADMIN
+# ===================================================================
+VAULTWARDEN_ADMIN_TOKEN=CHANGE-ME-generate-secure-admin-token
+
+# ===================================================================
+# SYSTEM CONFIGURATION
+# ===================================================================
+TZ=America/New_York
+PUID=501
+PGID=20
+
+# ===================================================================
+# EMAIL/SMTP CONFIGURATION (Optional)
+# ===================================================================
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=your-email@gmail.com
+SMTP_PASSWORD=your-app-password-CHANGE-ME
+SMTP_FROM=homelab@mbs-home.ddns.net
+SMTP_SECURITY=starttls
+
+# ===================================================================
+# GENERATION COMMANDS:
+# ===================================================================
+# Generate secure secrets:
+# openssl rand -base64 32  # For 32-character secrets
+# openssl rand -hex 16     # For 16-character hex secrets
+# uuidgen                  # For UUID-style secrets
+#
+# Example:
+# CF_DNS_API_TOKEN=$(openssl rand -base64 32)
+# AUTHELIA_SESSION_SECRET=$(openssl rand -base64 32)
+# AUTHELIA_STORAGE_ENCRYPTION_KEY=$(openssl rand -base64 32)
+# AUTHELIA_JWT_SECRET=$(openssl rand -base64 32)
+# VAULTWARDEN_ADMIN_TOKEN=$(openssl rand -base64 32)

--- a/MAC_HOMELAB_SETUP.md
+++ b/MAC_HOMELAB_SETUP.md
@@ -1,0 +1,238 @@
+# Mac Homelab External Drive Setup Guide
+
+## 🚀 Quick Start
+
+This guide will help you set up a complete homelab on macOS with external drive storage, resolving the 404 error issue with `mbs-home.ddns.net`.
+
+### Prerequisites
+
+- macOS with Docker Desktop installed
+- External drive mounted at `/Volumes/WorkDrive`
+- Cloudflare account with API token
+- Router with port forwarding capabilities
+
+## 📋 Step-by-Step Setup
+
+### 1. Initial Setup
+
+```bash
+# Run the setup script
+./mac-homelab-setup.sh
+```
+
+This script will:
+- ✅ Create directory structure on external drive
+- ✅ Set proper file permissions
+- ✅ Create Docker networks
+- ✅ Configure Mac firewall
+- ✅ Test Docker access to external drive
+
+### 2. Configure Environment Variables
+
+```bash
+# Copy the template
+cp .env.mac .env
+
+# Edit with your values
+nano .env
+```
+
+**Required values:**
+- `CF_API_EMAIL`: Your email address
+- `CF_DNS_API_TOKEN`: Cloudflare API token
+- `NEXTCLOUD_DB_PASSWORD`: Secure database password
+- `AUTHELIA_SESSION_SECRET`: Generate with `openssl rand -base64 32`
+- `AUTHELIA_STORAGE_ENCRYPTION_KEY`: Generate with `openssl rand -base64 32`
+- `AUTHELIA_JWT_SECRET`: Generate with `openssl rand -base64 32`
+- `VAULTWARDEN_ADMIN_TOKEN`: Generate with `openssl rand -base64 32`
+
+### 3. Deploy Services
+
+```bash
+# Deploy the homelab
+./deploy-mac-homelab.sh
+```
+
+### 4. Configure Router Port Forwarding
+
+Forward these ports to your Mac's IP address:
+- **Port 80** → Mac IP (HTTP)
+- **Port 443** → Mac IP (HTTPS)
+
+### 5. Configure Cloudflare DNS
+
+1. Go to Cloudflare Dashboard
+2. Add DNS record: `A` record `mbs-home` → Your public IP
+3. **IMPORTANT**: Set to "DNS only" (gray cloud), NOT proxied (orange cloud)
+4. Add wildcard: `CNAME` record `*.mbs-home` → `mbs-home.ddns.net`
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+#### 1. External Drive Not Accessible
+
+```bash
+# Check if drive is mounted
+mount | grep WorkDrive
+
+# Check Docker file sharing
+# Open Docker Desktop → Settings → Resources → File Sharing
+# Add: /Volumes/WorkDrive
+# Add: /Volumes/WorkDrive/MacStorage
+```
+
+#### 2. Services Return 404
+
+**Check these in order:**
+
+1. **Docker Desktop File Sharing**
+   ```bash
+   # Test Docker access
+   docker run --rm -v /Volumes/WorkDrive/MacStorage/docker:/data alpine ls -la /data
+   ```
+
+2. **Router Port Forwarding**
+   ```bash
+   # Get Mac's IP
+   ipconfig getifaddr en0  # WiFi
+   ipconfig getifaddr en1  # Ethernet
+   ```
+
+3. **Cloudflare DNS Settings**
+   - Ensure DNS records are "DNS only" (gray cloud)
+   - Not proxied (orange cloud)
+
+4. **Service Health**
+   ```bash
+   # Run health check
+   ./health-check-mac.sh
+   
+   # Check specific service
+   docker logs traefik
+   docker logs nextcloud
+   ```
+
+#### 3. SSL Certificate Issues
+
+```bash
+# Check acme.json permissions
+ls -la /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+# Should be: -rw------- (600)
+
+# Fix permissions if needed
+chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+```
+
+#### 4. Permission Issues
+
+```bash
+# Fix ownership
+sudo chown -R $(whoami):staff /Volumes/WorkDrive/MacStorage/docker/
+
+# Fix permissions
+chmod 755 /Volumes/WorkDrive/MacStorage/docker/traefik/config
+chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+```
+
+## 📊 Service URLs
+
+Once configured, access your services at:
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| **Homepage** | https://mbs-home.ddns.net | Main dashboard |
+| **Nextcloud** | https://nextcloud.mbs-home.ddns.net | File storage |
+| **Jellyfin** | https://jellyfin.mbs-home.ddns.net | Media server |
+| **Vaultwarden** | https://vault.mbs-home.ddns.net | Password manager |
+| **Authelia** | https://auth.mbs-home.ddns.net | Authentication |
+| **Traefik** | https://traefik.mbs-home.ddns.net | Reverse proxy |
+| **Portainer** | https://portainer.mbs-home.ddns.net | Container management |
+| **AdGuard** | https://dns.mbs-home.ddns.net | DNS server |
+
+## 🔍 Monitoring & Maintenance
+
+### Health Check
+
+```bash
+# Run comprehensive health check
+./health-check-mac.sh
+```
+
+### Service Management
+
+```bash
+# Start all services
+docker-compose -f docker-compose-mac.yml up -d
+
+# Stop all services
+docker-compose -f docker-compose-mac.yml down
+
+# View logs
+docker-compose -f docker-compose-mac.yml logs -f
+
+# Restart specific service
+docker-compose -f docker-compose-mac.yml restart nextcloud
+```
+
+### Backup
+
+```bash
+# Backup configuration
+tar -czf homelab-backup-$(date +%Y%m%d).tar.gz /Volumes/WorkDrive/MacStorage/docker/
+
+# Backup data only
+tar -czf homelab-data-$(date +%Y%m%d).tar.gz /Volumes/WorkDrive/MacStorage/docker/nextcloud/data
+```
+
+## 🛠️ Advanced Configuration
+
+### Custom Domains
+
+To use custom domains, update the Traefik labels in `docker-compose-mac.yml`:
+
+```yaml
+labels:
+  - "traefik.http.routers.nextcloud.rule=Host(`your-domain.com`)"
+```
+
+### Additional Services
+
+To add more services:
+
+1. Add service definition to `docker-compose-mac.yml`
+2. Use external drive paths: `/Volumes/WorkDrive/MacStorage/docker/service-name`
+3. Add Traefik labels for routing
+4. Update health check script
+
+### Security Hardening
+
+1. **Change default passwords** in `.env`
+2. **Enable Authelia** for additional services
+3. **Use strong secrets** (32+ characters)
+4. **Regular updates**: `docker-compose -f docker-compose-mac.yml pull && docker-compose -f docker-compose-mac.yml up -d`
+
+## 📞 Support
+
+If you encounter issues:
+
+1. Run `./health-check-mac.sh`
+2. Check service logs: `docker logs <service-name>`
+3. Verify external drive mount: `mount | grep WorkDrive`
+4. Test Docker access: `docker run --rm -v /Volumes/WorkDrive/MacStorage/docker:/data alpine ls -la /data`
+
+## 🎯 Expected Results
+
+After successful setup:
+
+- ✅ `mbs-home.ddns.net` → Nextcloud/Homepage
+- ✅ `jellyfin.mbs-home.ddns.net` → Jellyfin
+- ✅ `vault.mbs-home.ddns.net` → Vaultwarden
+- ✅ All services accessible with HTTPS
+- ✅ SSL certificates automatically managed
+- ✅ External drive storage working
+- ✅ Mobile app compatibility
+
+---
+
+**Note**: This setup is optimized for macOS with Docker Desktop. The external drive configuration ensures your data persists and is accessible even if you move the drive between Macs.

--- a/README_MAC_HOMELAB.md
+++ b/README_MAC_HOMELAB.md
@@ -1,0 +1,167 @@
+# 🏠 Mac Homelab External Drive Setup
+
+## 🚀 Quick Fix for mbs-home.ddns.net 404 Error
+
+This repository contains a complete solution for setting up a Mac homelab with external drive storage, specifically designed to resolve the 404 error issue with `mbs-home.ddns.net`.
+
+## 📁 Files Overview
+
+| File | Purpose |
+|------|---------|
+| `mac-homelab-setup.sh` | Initial setup script - run this first |
+| `deploy-mac-homelab.sh` | Deploy all services |
+| `test-mac-setup.sh` | Test setup without starting services |
+| `health-check-mac.sh` | Comprehensive health check |
+| `docker-compose-mac.yml` | Mac-optimized Docker Compose |
+| `.env.mac` | Environment variables template |
+| `traefik/config/traefik-mac.yml` | Traefik configuration for Mac |
+| `traefik/config/dynamic-mac.yml` | Dynamic Traefik configuration |
+| `MAC_HOMELAB_SETUP.md` | Detailed setup guide |
+
+## 🎯 Root Cause Analysis
+
+The 404 error with `mbs-home.ddns.net` is caused by:
+
+1. **Docker Desktop File Sharing**: Not configured for external drive
+2. **File Permissions**: Incorrect permissions on critical files
+3. **Network Configuration**: Docker networks not properly set up
+4. **Traefik Configuration**: Missing or incorrect SSL/TLS setup
+5. **Router Port Forwarding**: Ports 80/443 not forwarded to Mac
+
+## ⚡ Quick Start (5 Minutes)
+
+```bash
+# 1. Run setup script
+./mac-homelab-setup.sh
+
+# 2. Configure environment
+cp .env.mac .env
+nano .env  # Edit with your values
+
+# 3. Deploy services
+./deploy-mac-homelab.sh
+
+# 4. Configure router (ports 80,443 → Mac IP)
+# 5. Configure Cloudflare DNS (DNS only, not proxied)
+```
+
+## 🔧 Key Features
+
+- ✅ **External Drive Storage**: All data stored on `/Volumes/WorkDrive/MacStorage/docker/`
+- ✅ **Mac-Optimized Paths**: Correct paths for macOS with Docker Desktop
+- ✅ **Cloudflare DNS Challenge**: Automatic SSL certificate management
+- ✅ **Proper Permissions**: Mac-compatible file ownership and permissions
+- ✅ **Health Monitoring**: Comprehensive health check and monitoring
+- ✅ **Mobile Compatible**: Jellyfin and other services work on mobile
+- ✅ **Security**: Authelia authentication and secure headers
+
+## 🌐 Service URLs
+
+Once configured:
+
+- **Main Dashboard**: https://mbs-home.ddns.net
+- **Nextcloud**: https://nextcloud.mbs-home.ddns.net
+- **Jellyfin**: https://jellyfin.mbs-home.ddns.net
+- **Vaultwarden**: https://vault.mbs-home.ddns.net
+- **Portainer**: https://portainer.mbs-home.ddns.net
+- **Traefik Dashboard**: https://traefik.mbs-home.ddns.net
+
+## 🛠️ Troubleshooting
+
+### Common Issues
+
+1. **404 Error Still Occurs**
+   ```bash
+   # Check Docker file sharing
+   docker run --rm -v /Volumes/WorkDrive/MacStorage/docker:/data alpine ls -la /data
+   
+   # Check router port forwarding
+   ipconfig getifaddr en0  # Get Mac IP
+   
+   # Check Cloudflare DNS (must be DNS only, not proxied)
+   ```
+
+2. **Services Not Starting**
+   ```bash
+   # Run health check
+   ./health-check-mac.sh
+   
+   # Check logs
+   docker logs traefik
+   docker logs nextcloud
+   ```
+
+3. **Permission Issues**
+   ```bash
+   # Fix ownership
+   sudo chown -R $(whoami):staff /Volumes/WorkDrive/MacStorage/docker/
+   
+   # Fix acme.json permissions
+   chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+   ```
+
+## 📊 System Requirements
+
+- **macOS**: Any recent version with Docker Desktop
+- **External Drive**: Mounted at `/Volumes/WorkDrive`
+- **RAM**: 8GB+ recommended
+- **Storage**: 100GB+ on external drive
+- **Network**: Router with port forwarding capability
+- **DNS**: Cloudflare account with API token
+
+## 🔒 Security Features
+
+- **SSL/TLS**: Automatic certificate management with Let's Encrypt
+- **Authentication**: Authelia for secure access
+- **Headers**: Security headers for all services
+- **Network Isolation**: Internal networks for databases
+- **Rate Limiting**: Protection against abuse
+
+## 📈 Monitoring
+
+```bash
+# Health check
+./health-check-mac.sh
+
+# Service status
+docker ps
+
+# Resource usage
+docker stats
+
+# Logs
+docker-compose -f docker-compose-mac.yml logs -f
+```
+
+## 🚨 Important Notes
+
+1. **Docker Desktop File Sharing**: Must include `/Volumes/WorkDrive`
+2. **Cloudflare DNS**: Use "DNS only" (gray cloud), NOT proxied (orange cloud)
+3. **Router Configuration**: Forward ports 80 and 443 to your Mac's IP
+4. **File Permissions**: acme.json must have 600 permissions
+5. **External Drive**: Must be mounted before starting services
+
+## 🎉 Expected Results
+
+After successful setup:
+
+- ✅ `mbs-home.ddns.net` returns Nextcloud/Homepage (not 404)
+- ✅ All services accessible with HTTPS
+- ✅ SSL certificates automatically managed
+- ✅ External drive storage working
+- ✅ Mobile apps can connect to services
+- ✅ Comprehensive monitoring and health checks
+
+## 📞 Support
+
+If you encounter issues:
+
+1. Run `./test-mac-setup.sh` to verify prerequisites
+2. Run `./health-check-mac.sh` for comprehensive diagnostics
+3. Check the detailed guide: `MAC_HOMELAB_SETUP.md`
+4. Verify Docker Desktop file sharing settings
+5. Confirm router port forwarding configuration
+
+---
+
+**This setup is specifically designed for macOS with Docker Desktop and external drive storage. The configuration addresses all common issues that cause 404 errors in Mac homelab environments.**

--- a/deploy-mac-homelab.sh
+++ b/deploy-mac-homelab.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# ===================================================================
+# MAC HOMELAB DEPLOYMENT SCRIPT
+# ===================================================================
+# This script deploys the Mac homelab with proper startup sequence
+# Run this script after setting up Docker Desktop and external drive
+# ===================================================================
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+echo "🚀 Deploying Mac Homelab..."
+echo "=========================="
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    print_error "This script is designed for macOS only!"
+    exit 1
+fi
+
+# Check if Docker Desktop is running
+if ! docker info >/dev/null 2>&1; then
+    print_error "Docker Desktop is not running! Please start Docker Desktop first."
+    exit 1
+fi
+
+# Check if external drive is mounted
+if [ ! -d "/Volumes/WorkDrive" ]; then
+    print_error "External drive '/Volumes/WorkDrive' is not mounted!"
+    print_status "Please mount your external drive and run the setup script first:"
+    echo "  ./mac-homelab-setup.sh"
+    exit 1
+fi
+
+# Check if .env file exists
+if [ ! -f ".env" ]; then
+    print_warning ".env file not found. Creating from template..."
+    cp .env.mac .env
+    print_warning "Please edit .env file with your actual values before continuing!"
+    print_status "Required values:"
+    echo "  - CF_API_EMAIL (your email)"
+    echo "  - CF_DNS_API_TOKEN (Cloudflare API token)"
+    echo "  - All password fields"
+    echo ""
+    read -p "Press Enter after editing .env file, or Ctrl+C to exit..."
+fi
+
+# Load environment variables
+if [ -f ".env" ]; then
+    export $(cat .env | grep -v '^#' | xargs)
+    print_success "Environment variables loaded"
+else
+    print_error ".env file not found!"
+    exit 1
+fi
+
+# Create necessary directories
+print_status "Creating required directories..."
+mkdir -p /Volumes/WorkDrive/MacStorage/docker/{traefik/{config,certificates},nextcloud/{config,data,custom_apps,themes,postgres,redis},jellyfin/{config,cache},authelia,vaultwarden,adguard/{work,conf},portainer,homepage/config}
+
+# Set proper permissions
+print_status "Setting file permissions..."
+chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json 2>/dev/null || true
+chmod 755 /Volumes/WorkDrive/MacStorage/docker/traefik/config
+chmod 755 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates
+
+# Fix ownership
+print_status "Fixing ownership..."
+sudo chown -R $(whoami):staff /Volumes/WorkDrive/MacStorage/docker/
+
+# Copy Traefik configuration
+print_status "Setting up Traefik configuration..."
+cp traefik/config/traefik-mac.yml /Volumes/WorkDrive/MacStorage/docker/traefik/config/traefik.yml
+cp traefik/config/dynamic-mac.yml /Volumes/WorkDrive/MacStorage/docker/traefik/config/dynamic.yml
+
+# Create acme.json if it doesn't exist
+if [ ! -f "/Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json" ]; then
+    print_status "Creating acme.json file..."
+    touch /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+    chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+fi
+
+# Create Docker networks
+print_status "Creating Docker networks..."
+docker network create homelab-main 2>/dev/null || print_warning "Network homelab-main already exists"
+docker network create homelab-media 2>/dev/null || print_warning "Network homelab-media already exists"
+docker network create homelab-mgmt 2>/dev/null || print_warning "Network homelab-mgmt already exists"
+docker network create homelab-db 2>/dev/null || print_warning "Network homelab-db already exists"
+
+# Clean up any existing containers
+print_status "Cleaning up existing containers..."
+docker-compose -f docker-compose-mac.yml down 2>/dev/null || true
+
+# Start services in proper order
+print_status "Starting services in deployment order..."
+
+# 1. Start Traefik first
+print_status "Starting Traefik..."
+docker-compose -f docker-compose-mac.yml up -d traefik
+sleep 10
+
+# Check Traefik health
+if docker logs traefik 2>&1 | grep -q "Configuration loaded"; then
+    print_success "Traefik started successfully"
+else
+    print_warning "Traefik may have issues, checking logs..."
+    docker logs traefik --tail 10
+fi
+
+# 2. Start database services
+print_status "Starting database services..."
+docker-compose -f docker-compose-mac.yml up -d nextcloud-db nextcloud-redis
+sleep 15
+
+# 3. Start core services
+print_status "Starting core services..."
+docker-compose -f docker-compose-mac.yml up -d nextcloud authelia vaultwarden
+sleep 20
+
+# 4. Start remaining services
+print_status "Starting remaining services..."
+docker-compose -f docker-compose-mac.yml up -d
+
+# Wait for all services to start
+print_status "Waiting for all services to start..."
+sleep 30
+
+# Check service status
+print_status "Checking service status..."
+echo ""
+echo "Running containers:"
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+echo ""
+
+# Test local connectivity
+print_status "Testing local connectivity..."
+if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080 >/dev/null 2>&1; then
+    print_success "Traefik dashboard accessible at http://localhost:8080"
+else
+    print_warning "Traefik dashboard not accessible locally"
+fi
+
+# Get Mac's local IP
+mac_ip=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "unknown")
+print_status "Mac local IP: $mac_ip"
+
+print_success "Mac homelab deployment completed!"
+echo ""
+echo "Next steps:"
+echo "1. Configure your router to forward ports 80 and 443 to Mac IP: $mac_ip"
+echo "2. Set up Cloudflare DNS with 'DNS only' (gray cloud) for mbs-home.ddns.net"
+echo "3. Test external access: https://mbs-home.ddns.net"
+echo "4. Run health check: ./health-check-mac.sh"
+echo ""
+echo "Service URLs (once DNS is configured):"
+echo "  - https://mbs-home.ddns.net (Nextcloud/Homepage)"
+echo "  - https://jellyfin.mbs-home.ddns.net (Jellyfin)"
+echo "  - https://vault.mbs-home.ddns.net (Vaultwarden)"
+echo "  - https://auth.mbs-home.ddns.net (Authelia)"
+echo "  - https://traefik.mbs-home.ddns.net (Traefik Dashboard)"
+echo "  - https://portainer.mbs-home.ddns.net (Portainer)"
+echo ""
+echo "Local access:"
+echo "  - Traefik Dashboard: http://localhost:8080"
+echo "  - Portainer: http://localhost:9000"

--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -1,0 +1,481 @@
+version: '3.8'
+
+# =================== Global Extensions ===================
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+    compress: "true"
+
+x-common-configs: &common-configs
+  logging: *default-logging
+  restart: unless-stopped
+
+x-healthcheck-defaults: &healthcheck-defaults
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 40s
+
+# ===================================================================
+# Mac Homelab Stack - External Drive Optimized
+# Key Features:
+# - Optimized for macOS with Docker Desktop
+# - External drive storage at /Volumes/WorkDrive/MacStorage/docker/
+# - Cloudflare DNS challenge for SSL certificates
+# - Proper Mac file permissions and ownership
+# - Network configuration for Mac networking
+# ===================================================================
+
+networks:
+  homelab-main:
+    name: homelab-main
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/16
+  homelab-media:
+    name: homelab-media
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.31.0.0/16
+  homelab-mgmt:
+    name: homelab-mgmt
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.32.0.0/16
+  homelab-db:
+    name: homelab-db
+    driver: bridge
+    internal: true
+    ipam:
+      config:
+        - subnet: 172.33.0.0/16
+
+services:
+
+# =================== Reverse Proxy & SSL ===================
+
+  traefik:
+    <<: *common-configs
+    image: traefik:v3.1
+    container_name: traefik
+    hostname: traefik
+    networks:
+      - homelab-main
+      - homelab-mgmt
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"  # Dashboard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /Volumes/WorkDrive/MacStorage/docker/traefik/config:/etc/traefik:ro
+      - /Volumes/WorkDrive/MacStorage/docker/traefik/certificates:/certificates
+    environment:
+      - TZ=${TZ:-America/New_York}
+      - CF_API_EMAIL=${CF_API_EMAIL}
+      - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
+    command:
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=homelab-main"
+      - "--providers.file.filename=/etc/traefik/dynamic.yml"
+      - "--providers.file.watch=true"
+      - "--certificatesresolvers.cloudflare.acme.dnschallenge=true"
+      - "--certificatesresolvers.cloudflare.acme.dnschallenge.provider=cloudflare"
+      - "--certificatesresolvers.cloudflare.acme.email=${CF_API_EMAIL}"
+      - "--certificatesresolvers.cloudflare.acme.storage=/certificates/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencrypt.acme.email=${CF_API_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/certificates/acme.json"
+      - "--log.level=INFO"
+      - "--accesslog=true"
+      - "--metrics.prometheus=true"
+      - "--metrics.prometheus.addEntryPointsLabels=true"
+      - "--metrics.prometheus.addServicesLabels=true"
+      - "--global.checkNewVersion=false"
+      - "--global.sendAnonymousUsage=false"
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api/rawdata"]
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.5'
+        reservations:
+          memory: 128M
+          cpus: '0.2'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik-secure.rule=Host(`traefik.mbs-home.ddns.net`)"
+      - "traefik.http.routers.traefik-secure.entrypoints=websecure"
+      - "traefik.http.routers.traefik-secure.service=api@internal"
+      - "traefik.http.routers.traefik-secure.tls.certresolver=cloudflare"
+      - "traefik.http.services.traefik.loadbalancer.server.port=8080"
+      - "traefik.http.routers.traefik-secure.middlewares=secure-headers@file"
+
+# =================== DNS & Network Security ===================
+
+  adguard:
+    <<: *common-configs
+    image: adguard/adguardhome:latest
+    container_name: adguard-home
+    hostname: adguard-home
+    networks:
+      - homelab-main
+      - homelab-mgmt
+    ports:
+      - target: 53
+        published: 53
+        protocol: tcp
+        mode: host
+      - target: 53
+        published: 53
+        protocol: udp
+        mode: host
+      - "853:853/tcp"   # DNS over TLS
+      - "5443:5443/tcp" # DNS over QUIC
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/adguard/work:/opt/adguardhome/work
+      - /Volumes/WorkDrive/MacStorage/docker/adguard/conf:/opt/adguardhome/conf
+    environment:
+      - TZ=${TZ:-America/New_York}
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "nslookup", "google.com", "127.0.0.1"]
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+          cpus: '0.1'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.adguard.rule=Host(`dns.mbs-home.ddns.net`)"
+      - "traefik.http.routers.adguard.entrypoints=websecure"
+      - "traefik.http.routers.adguard.tls.certresolver=cloudflare"
+      - "traefik.http.routers.adguard.middlewares=authelia@file,secure-headers@file"
+      - "traefik.http.services.adguard.loadbalancer.server.port=3000"
+
+# =================== Authentication & Security ===================
+
+  authelia:
+    <<: *common-configs
+    image: authelia/authelia:latest
+    container_name: authelia
+    hostname: authelia
+    networks:
+      - homelab-main
+      - homelab-db
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/authelia:/config
+    environment:
+      - TZ=${TZ:-America/New_York}
+      - AUTHELIA_SESSION_SECRET=${AUTHELIA_SESSION_SECRET}
+      - AUTHELIA_STORAGE_ENCRYPTION_KEY=${AUTHELIA_STORAGE_ENCRYPTION_KEY}
+      - AUTHELIA_JWT_SECRET=${AUTHELIA_JWT_SECRET}
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9091/api/health"]
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.3'
+        reservations:
+          memory: 128M
+          cpus: '0.1'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.authelia.rule=Host(`auth.mbs-home.ddns.net`)"
+      - "traefik.http.routers.authelia.entrypoints=websecure"
+      - "traefik.http.routers.authelia.tls.certresolver=cloudflare"
+      - "traefik.http.services.authelia.loadbalancer.server.port=9091"
+
+  vaultwarden:
+    <<: *common-configs
+    image: vaultwarden/server:latest
+    container_name: vaultwarden
+    hostname: vaultwarden
+    networks:
+      - homelab-main
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/vaultwarden:/data
+    environment:
+      - TZ=${TZ:-America/New_York}
+      - WEBSOCKET_ENABLED=true
+      - SIGNUPS_ALLOWED=false
+      - ADMIN_TOKEN=${VAULTWARDEN_ADMIN_TOKEN}
+      - DOMAIN=https://vault.mbs-home.ddns.net
+      - SMTP_HOST=${SMTP_HOST:-localhost}
+      - SMTP_FROM=${SMTP_FROM:-vaultwarden@mbs-home.ddns.net}
+      - SMTP_FROM_NAME=Vaultwarden
+      - SMTP_PORT=${SMTP_PORT:-587}
+      - SMTP_SECURITY=${SMTP_SECURITY:-starttls}
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "curl", "-f", "http://localhost:80/alive"]
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.3'
+        reservations:
+          memory: 128M
+          cpus: '0.1'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vaultwarden.rule=Host(`vault.mbs-home.ddns.net`)"
+      - "traefik.http.routers.vaultwarden.entrypoints=websecure"
+      - "traefik.http.routers.vaultwarden.tls.certresolver=cloudflare"
+      - "traefik.http.routers.vaultwarden.middlewares=secure-headers@file"
+      - "traefik.http.services.vaultwarden.loadbalancer.server.port=80"
+      # WebSocket support
+      - "traefik.http.routers.vaultwarden-ws.rule=Host(`vault.mbs-home.ddns.net`) && Path(`/notifications/hub`)"
+      - "traefik.http.routers.vaultwarden-ws.entrypoints=websecure"
+      - "traefik.http.routers.vaultwarden-ws.tls.certresolver=cloudflare"
+      - "traefik.http.services.vaultwarden-ws.loadbalancer.server.port=3012"
+
+# =================== Cloud Storage & Productivity ===================
+
+  nextcloud-db:
+    <<: *common-configs
+    image: postgres:15-alpine
+    container_name: nextcloud-db
+    hostname: nextcloud-db
+    networks:
+      - homelab-db
+    environment:
+      - POSTGRES_DB=nextcloud
+      - POSTGRES_USER=nextcloud
+      - POSTGRES_PASSWORD=${NEXTCLOUD_DB_PASSWORD}
+      - TZ=${TZ:-America/New_York}
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/nextcloud/postgres:/var/lib/postgresql/data
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD-SHELL", "pg_isready -U nextcloud -d nextcloud"]
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+          cpus: '0.2'
+
+  nextcloud-redis:
+    <<: *common-configs
+    image: redis:7-alpine
+    container_name: nextcloud-redis
+    hostname: nextcloud-redis
+    networks:
+      - homelab-db
+    command: ["redis-server", "--appendonly", "yes", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/nextcloud/redis:/data
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "redis-cli", "ping"]
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.3'
+        reservations:
+          memory: 128M
+          cpus: '0.1'
+
+  nextcloud:
+    <<: *common-configs
+    image: nextcloud:latest
+    container_name: nextcloud
+    hostname: nextcloud
+    networks:
+      - homelab-main
+      - homelab-db
+    depends_on:
+      - nextcloud-db
+      - nextcloud-redis
+    environment:
+      - PUID=${PUID:-501}
+      - PGID=${PGID:-20}
+      - TZ=${TZ:-America/New_York}
+      # Database configuration
+      - POSTGRES_HOST=nextcloud-db
+      - POSTGRES_DB=nextcloud
+      - POSTGRES_USER=nextcloud
+      - POSTGRES_PASSWORD=${NEXTCLOUD_DB_PASSWORD}
+      # Redis configuration
+      - REDIS_HOST=nextcloud-redis
+      - REDIS_HOST_PORT=6379
+      # Nextcloud configuration
+      - NEXTCLOUD_ADMIN_USER=${NEXTCLOUD_ADMIN_USER:-admin}
+      - NEXTCLOUD_ADMIN_PASSWORD=${NEXTCLOUD_ADMIN_PASSWORD}
+      - NEXTCLOUD_TRUSTED_DOMAINS=mbs-home.ddns.net nextcloud.mbs-home.ddns.net
+      - TRUSTED_PROXIES=172.30.0.0/16
+      - OVERWRITEPROTOCOL=https
+      - OVERWRITEHOST=mbs-home.ddns.net
+      - OVERWRITE_CLI_URL=https://mbs-home.ddns.net
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/nextcloud/config:/var/www/html/config
+      - /Volumes/WorkDrive/MacStorage/docker/nextcloud/custom_apps:/var/www/html/custom_apps
+      - /Volumes/WorkDrive/MacStorage/docker/nextcloud/data:/var/www/html/data
+      - /Volumes/WorkDrive/MacStorage/docker/nextcloud/themes:/var/www/html/themes
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "curl", "-f", "http://localhost:80/status.php"]
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
+        reservations:
+          memory: 512M
+          cpus: '0.3'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nextcloud.rule=Host(`mbs-home.ddns.net`) || Host(`nextcloud.mbs-home.ddns.net`)"
+      - "traefik.http.routers.nextcloud.entrypoints=websecure"
+      - "traefik.http.routers.nextcloud.tls.certresolver=cloudflare"
+      - "traefik.http.routers.nextcloud.middlewares=nextcloud-headers,secure-headers@file"
+      - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
+      # Nextcloud specific headers
+      - "traefik.http.middlewares.nextcloud-headers.headers.customRequestHeaders.X-Forwarded-Proto=https"
+      - "traefik.http.middlewares.nextcloud-headers.headers.customRequestHeaders.X-Forwarded-Ssl=on"
+      - "traefik.http.middlewares.nextcloud-headers.headers.customRequestHeaders.X-Forwarded-Host=mbs-home.ddns.net"
+      - "traefik.http.middlewares.nextcloud-headers.headers.customResponseHeaders.Referrer-Policy=no-referrer"
+
+# =================== Media Services ===================
+
+  jellyfin:
+    <<: *common-configs
+    image: lscr.io/linuxserver/jellyfin:latest
+    container_name: jellyfin
+    hostname: jellyfin
+    networks:
+      - homelab-main
+      - homelab-media
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/jellyfin/config:/config
+      - /Volumes/WorkDrive/MacStorage/docker/jellyfin/cache:/cache
+      - /Volumes/WorkDrive/MacStorage/Media/Movies:/data/movies:ro
+      - /Volumes/WorkDrive/MacStorage/Media/Music:/data/music:ro
+      - /Volumes/WorkDrive/MacStorage/Media/TV:/data/tvshows:ro
+    environment:
+      - PUID=${PUID:-501}
+      - PGID=${PGID:-20}
+      - TZ=${TZ:-America/New_York}
+      - JELLYFIN_PublishedServerUrl=https://jellyfin.mbs-home.ddns.net
+      # Fix mobile connectivity issues
+      - JELLYFIN_CACHE_DIR=/cache
+      - JELLYFIN_CONFIG_DIR=/config
+      - JELLYFIN_DATA_DIR=/config/data
+      - JELLYFIN_LOG_DIR=/config/log
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "curl", "-f", "http://localhost:8096/health"]
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: '2.0'
+        reservations:
+          memory: 1G
+          cpus: '0.5'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.mbs-home.ddns.net`)"
+      - "traefik.http.routers.jellyfin.entrypoints=websecure"
+      - "traefik.http.routers.jellyfin.tls.certresolver=cloudflare"
+      - "traefik.http.routers.jellyfin.middlewares=jellyfin-headers,secure-headers@file"
+      - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
+      # Mobile app connectivity improvements
+      - "traefik.http.middlewares.jellyfin-headers.headers.customRequestHeaders.X-Forwarded-Proto=https"
+      - "traefik.http.middlewares.jellyfin-headers.headers.customRequestHeaders.X-Forwarded-Host=jellyfin.mbs-home.ddns.net"
+      - "traefik.http.middlewares.jellyfin-headers.headers.customRequestHeaders.X-Forwarded-For=$$remote_addr"
+
+# =================== Management & Dashboards ===================
+
+  portainer:
+    <<: *common-configs
+    image: portainer/portainer-ce:latest
+    container_name: portainer
+    hostname: portainer
+    networks:
+      - homelab-main
+      - homelab-mgmt
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/portainer:/data
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - TZ=${TZ:-America/New_York}
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9000"]
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+          cpus: '0.2'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portainer.rule=Host(`portainer.mbs-home.ddns.net`)"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
+      - "traefik.http.routers.portainer.tls.certresolver=cloudflare"
+      - "traefik.http.routers.portainer.middlewares=authelia@file,secure-headers@file"
+      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+
+  homepage:
+    <<: *common-configs
+    image: ghcr.io/gethomepage/homepage:latest
+    container_name: homepage
+    hostname: homepage
+    networks:
+      - homelab-main
+      - homelab-media
+      - homelab-mgmt
+    volumes:
+      - /Volumes/WorkDrive/MacStorage/docker/homepage/config:/app/config
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - TZ=${TZ:-America/New_York}
+      - PUID=${PUID:-501}
+      - PGID=${PGID:-20}
+      - HOMEPAGE_ALLOWED_HOSTS=mbs-home.ddns.net,home.local,dashboard.local,192.168.1.191
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000"]
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.3'
+        reservations:
+          memory: 128M
+          cpus: '0.1'
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.homepage.rule=Host(`mbs-home.ddns.net`) || Host(`home.local`) || Host(`dashboard.local`)"
+      - "traefik.http.routers.homepage.entrypoints=websecure"
+      - "traefik.http.routers.homepage.tls.certresolver=cloudflare"
+      - "traefik.http.routers.homepage.middlewares=authelia@file,secure-headers@file"
+      - "traefik.http.services.homepage.loadbalancer.server.port=3000"

--- a/health-check-mac.sh
+++ b/health-check-mac.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+# ===================================================================
+# MAC HOMELAB HEALTH CHECK SCRIPT
+# ===================================================================
+# This script checks the health of all homelab services
+# Run this script to diagnose issues and verify service status
+# ===================================================================
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+echo "🏥 Mac Homelab Health Check"
+echo "============================"
+echo "Date: $(date)"
+echo ""
+
+# Check if Docker is running
+print_status "Checking Docker Desktop..."
+if docker info >/dev/null 2>&1; then
+    print_success "Docker Desktop is running"
+else
+    print_error "Docker Desktop is not running!"
+    exit 1
+fi
+
+# Check external drive mount
+print_status "Checking external drive mount..."
+if [ -d "/Volumes/WorkDrive" ]; then
+    print_success "External drive is mounted at /Volumes/WorkDrive"
+    if [ -d "/Volumes/WorkDrive/MacStorage/docker" ]; then
+        print_success "Docker directory exists on external drive"
+    else
+        print_warning "Docker directory not found on external drive"
+    fi
+else
+    print_error "External drive not mounted at /Volumes/WorkDrive!"
+    print_warning "Please mount your external drive and run the setup script"
+fi
+
+# Check Docker networks
+print_status "Checking Docker networks..."
+networks=("homelab-main" "homelab-media" "homelab-mgmt" "homelab-db")
+for network in "${networks[@]}"; do
+    if docker network ls | grep -q "$network"; then
+        print_success "Network $network exists"
+    else
+        print_warning "Network $network not found"
+    fi
+done
+
+# Check running containers
+print_status "Checking running containers..."
+echo ""
+echo "Docker Services:"
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" | head -20
+echo ""
+
+# Check disk space
+print_status "Checking disk space..."
+echo "External Drive Usage:"
+df -h /Volumes/WorkDrive 2>/dev/null || print_warning "Cannot check external drive usage"
+echo ""
+
+# Check Mac's local IP
+print_status "Getting Mac's local IP address..."
+mac_ip_wifi=$(ipconfig getifaddr en0 2>/dev/null || echo "Not available")
+mac_ip_ethernet=$(ipconfig getifaddr en1 2>/dev/null || echo "Not available")
+echo "WiFi IP: $mac_ip_wifi"
+echo "Ethernet IP: $mac_ip_ethernet"
+echo ""
+
+# Check router port forwarding (manual check)
+print_status "Router Port Forwarding Check:"
+print_warning "Manual verification required:"
+echo "1. Check your router settings"
+echo "2. Ensure ports 80 and 443 are forwarded to Mac IP: $mac_ip_wifi"
+echo "3. Verify Cloudflare DNS settings (DNS only, not proxied)"
+echo ""
+
+# Check service health
+print_status "Checking service health..."
+services=("traefik" "nextcloud" "jellyfin" "vaultwarden" "authelia" "adguard-home" "portainer" "homepage")
+
+for service in "${services[@]}"; do
+    if docker ps | grep -q "$service"; then
+        print_success "$service is running"
+        # Check if service is healthy
+        if docker inspect "$service" | grep -q '"Health": "healthy"'; then
+            print_success "$service is healthy"
+        else
+            print_warning "$service is running but not healthy"
+        fi
+    else
+        print_error "$service is not running"
+    fi
+done
+
+echo ""
+
+# Check service logs for errors
+print_status "Checking recent service logs for errors..."
+for service in "${services[@]}"; do
+    if docker ps | grep -q "$service"; then
+        echo "--- $service logs (last 5 lines) ---"
+        docker logs "$service" --tail 5 2>/dev/null | grep -i error || echo "No errors found"
+        echo ""
+    fi
+done
+
+# Test local connectivity
+print_status "Testing local connectivity..."
+if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080 >/dev/null 2>&1; then
+    print_success "Traefik dashboard accessible locally"
+else
+    print_warning "Traefik dashboard not accessible locally"
+fi
+
+# Test external connectivity (if domain is configured)
+print_status "Testing external connectivity..."
+if command -v nslookup >/dev/null 2>&1; then
+    if nslookup mbs-home.ddns.net >/dev/null 2>&1; then
+        print_success "DNS resolution working for mbs-home.ddns.net"
+        
+        # Test HTTPS connectivity
+        if curl -s -o /dev/null -w "%{http_code}" https://mbs-home.ddns.net >/dev/null 2>&1; then
+            response_code=$(curl -s -o /dev/null -w "%{http_code}" https://mbs-home.ddns.net)
+            if [ "$response_code" = "200" ]; then
+                print_success "HTTPS connectivity working (HTTP $response_code)"
+            else
+                print_warning "HTTPS connectivity issue (HTTP $response_code)"
+            fi
+        else
+            print_warning "HTTPS connectivity failed"
+        fi
+    else
+        print_warning "DNS resolution failed for mbs-home.ddns.net"
+    fi
+else
+    print_warning "nslookup not available, skipping DNS test"
+fi
+
+echo ""
+print_status "Health check completed!"
+echo ""
+echo "If you're experiencing issues:"
+echo "1. Check Docker Desktop file sharing settings"
+echo "2. Verify external drive is mounted and accessible"
+echo "3. Check router port forwarding (80, 443 → Mac IP)"
+echo "4. Verify Cloudflare DNS settings (DNS only, not proxied)"
+echo "5. Check service logs: docker logs <service-name>"
+echo ""
+echo "For detailed troubleshooting, run:"
+echo "  docker-compose logs <service-name>"
+echo "  docker system df"
+echo "  docker system prune -f  # Clean up if needed"

--- a/mac-homelab-setup.sh
+++ b/mac-homelab-setup.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# ===================================================================
+# MAC HOMELAB EXTERNAL DRIVE SETUP SCRIPT
+# ===================================================================
+# This script sets up the Mac homelab with external drive support
+# Run this script to configure Docker Desktop and fix permissions
+# ===================================================================
+
+set -e
+
+echo "🚀 Starting Mac Homelab External Drive Setup..."
+echo "=============================================="
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    print_error "This script is designed for macOS only!"
+    exit 1
+fi
+
+# Check if Docker Desktop is running
+if ! docker info >/dev/null 2>&1; then
+    print_error "Docker Desktop is not running! Please start Docker Desktop first."
+    exit 1
+fi
+
+print_status "Docker Desktop is running ✓"
+
+# Check if external drive is mounted
+if [ ! -d "/Volumes/WorkDrive" ]; then
+    print_warning "External drive '/Volumes/WorkDrive' is not mounted!"
+    print_status "Please mount your external drive and ensure it's accessible at /Volumes/WorkDrive"
+    print_status "You can check mounted drives with: mount | grep WorkDrive"
+    read -p "Press Enter when the drive is mounted, or Ctrl+C to exit..."
+fi
+
+if [ ! -d "/Volumes/WorkDrive/MacStorage" ]; then
+    print_status "Creating MacStorage directory structure..."
+    mkdir -p /Volumes/WorkDrive/MacStorage/docker
+    print_success "Created directory structure"
+fi
+
+# Create necessary directories
+print_status "Creating required directories..."
+mkdir -p /Volumes/WorkDrive/MacStorage/docker/{traefik/{config,certificates},nextcloud/{config,data,custom_apps,themes,postgres,redis},jellyfin/{config,cache},authelia,vaultwarden,adguard/{work,conf},wireguard/config,portainer,homepage/config,grafana/{data,config},prometheus/{config,data,blackbox},homeassistant,scripts,logs/homelab-reports,ai-local/open-webui}
+
+# Set proper permissions
+print_status "Setting file permissions..."
+chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json 2>/dev/null || true
+chmod 755 /Volumes/WorkDrive/MacStorage/docker/traefik/config
+chmod 755 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates
+
+# Fix ownership
+print_status "Fixing ownership..."
+sudo chown -R $(whoami):staff /Volumes/WorkDrive/MacStorage/docker/
+
+print_success "Directory structure and permissions configured"
+
+# Check Docker Desktop file sharing
+print_status "Checking Docker Desktop file sharing configuration..."
+print_warning "IMPORTANT: You need to manually configure Docker Desktop file sharing:"
+echo ""
+echo "1. Open Docker Desktop"
+echo "2. Go to Settings → Resources → File Sharing"
+echo "3. Add these paths:"
+echo "   - /Volumes/WorkDrive"
+echo "   - /Volumes/WorkDrive/MacStorage"
+echo "4. Click 'Apply & Restart'"
+echo ""
+
+# Test Docker access to external drive
+print_status "Testing Docker access to external drive..."
+if docker run --rm -v /Volumes/WorkDrive/MacStorage/docker:/data alpine ls -la /data >/dev/null 2>&1; then
+    print_success "Docker can access external drive ✓"
+else
+    print_error "Docker cannot access external drive!"
+    print_warning "Please ensure Docker Desktop file sharing is configured correctly"
+    exit 1
+fi
+
+# Create Docker networks
+print_status "Creating Docker networks..."
+docker network create homelab-main 2>/dev/null || print_warning "Network homelab-main already exists"
+docker network create homelab-media 2>/dev/null || print_warning "Network homelab-media already exists"
+docker network create homelab-mgmt 2>/dev/null || print_warning "Network homelab-mgmt already exists"
+docker network create homelab-db 2>/dev/null || print_warning "Network homelab-db already exists"
+
+print_success "Docker networks created"
+
+# Check Mac firewall
+print_status "Checking Mac firewall..."
+firewall_state=$(sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null | grep -o "enabled\|disabled" || echo "unknown")
+
+if [ "$firewall_state" = "enabled" ]; then
+    print_warning "Mac firewall is enabled. Adding Docker to firewall exceptions..."
+    sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add /Applications/Docker.app 2>/dev/null || true
+    sudo /usr/libexec/ApplicationFirewall/socketfilterfw --unblockapp /Applications/Docker.app 2>/dev/null || true
+    print_success "Docker added to firewall exceptions"
+else
+    print_status "Mac firewall is $firewall_state"
+fi
+
+# Get Mac's local IP
+print_status "Getting Mac's local IP address..."
+mac_ip_wifi=$(ipconfig getifaddr en0 2>/dev/null || echo "Not available")
+mac_ip_ethernet=$(ipconfig getifaddr en1 2>/dev/null || echo "Not available")
+
+echo "WiFi IP: $mac_ip_wifi"
+echo "Ethernet IP: $mac_ip_ethernet"
+
+# Create acme.json if it doesn't exist
+if [ ! -f "/Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json" ]; then
+    print_status "Creating acme.json file..."
+    touch /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+    chmod 600 /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json
+    print_success "Created acme.json with correct permissions"
+fi
+
+print_success "Mac homelab setup completed!"
+echo ""
+echo "Next steps:"
+echo "1. Ensure Docker Desktop file sharing is configured (see instructions above)"
+echo "2. Configure your router to forward ports 80 and 443 to your Mac's IP: $mac_ip_wifi"
+echo "3. Set up Cloudflare DNS with 'DNS only' (gray cloud) for mbs-home.ddns.net"
+echo "4. Run: docker-compose up -d"
+echo ""
+echo "For troubleshooting, run: ./health-check.sh"

--- a/test-mac-setup.sh
+++ b/test-mac-setup.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# ===================================================================
+# MAC HOMELAB SETUP TEST SCRIPT
+# ===================================================================
+# This script tests the Mac homelab setup without starting services
+# ===================================================================
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+echo "🧪 Testing Mac Homelab Setup"
+echo "============================"
+
+# Test 1: Check if running on macOS
+print_status "Test 1: Checking macOS..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    print_success "Running on macOS"
+else
+    print_error "Not running on macOS!"
+    exit 1
+fi
+
+# Test 2: Check Docker Desktop
+print_status "Test 2: Checking Docker Desktop..."
+if docker info >/dev/null 2>&1; then
+    print_success "Docker Desktop is running"
+else
+    print_error "Docker Desktop is not running!"
+    exit 1
+fi
+
+# Test 3: Check external drive
+print_status "Test 3: Checking external drive..."
+if [ -d "/Volumes/WorkDrive" ]; then
+    print_success "External drive mounted at /Volumes/WorkDrive"
+else
+    print_error "External drive not mounted at /Volumes/WorkDrive!"
+    print_warning "Please mount your external drive first"
+    exit 1
+fi
+
+# Test 4: Check Docker file sharing
+print_status "Test 4: Testing Docker file sharing..."
+if docker run --rm -v /Volumes/WorkDrive/MacStorage/docker:/data alpine ls -la /data >/dev/null 2>&1; then
+    print_success "Docker can access external drive"
+else
+    print_error "Docker cannot access external drive!"
+    print_warning "Please configure Docker Desktop file sharing:"
+    echo "  1. Open Docker Desktop"
+    echo "  2. Go to Settings → Resources → File Sharing"
+    echo "  3. Add: /Volumes/WorkDrive"
+    echo "  4. Add: /Volumes/WorkDrive/MacStorage"
+    echo "  5. Click 'Apply & Restart'"
+    exit 1
+fi
+
+# Test 5: Check required files
+print_status "Test 5: Checking required files..."
+required_files=(
+    "docker-compose-mac.yml"
+    ".env.mac"
+    "traefik/config/traefik-mac.yml"
+    "traefik/config/dynamic-mac.yml"
+    "mac-homelab-setup.sh"
+    "deploy-mac-homelab.sh"
+    "health-check-mac.sh"
+)
+
+for file in "${required_files[@]}"; do
+    if [ -f "$file" ]; then
+        print_success "Found $file"
+    else
+        print_error "Missing $file"
+        exit 1
+    fi
+done
+
+# Test 6: Check .env file
+print_status "Test 6: Checking .env file..."
+if [ -f ".env" ]; then
+    print_success ".env file exists"
+    
+    # Check for required variables
+    if grep -q "CF_API_EMAIL" .env && grep -q "CF_DNS_API_TOKEN" .env; then
+        print_success "Required environment variables found"
+    else
+        print_warning "Please configure .env file with your values"
+    fi
+else
+    print_warning ".env file not found, will be created from template"
+fi
+
+# Test 7: Check directory structure
+print_status "Test 7: Checking directory structure..."
+if [ -d "/Volumes/WorkDrive/MacStorage/docker" ]; then
+    print_success "Docker directory exists on external drive"
+else
+    print_warning "Docker directory not found, will be created"
+fi
+
+# Test 8: Check Mac IP
+print_status "Test 8: Getting Mac IP address..."
+mac_ip_wifi=$(ipconfig getifaddr en0 2>/dev/null || echo "Not available")
+mac_ip_ethernet=$(ipconfig getifaddr en1 2>/dev/null || echo "Not available")
+echo "WiFi IP: $mac_ip_wifi"
+echo "Ethernet IP: $mac_ip_ethernet"
+
+if [ "$mac_ip_wifi" != "Not available" ] || [ "$mac_ip_ethernet" != "Not available" ]; then
+    print_success "Mac IP address found"
+else
+    print_warning "Could not determine Mac IP address"
+fi
+
+# Test 9: Check Docker networks
+print_status "Test 9: Checking Docker networks..."
+networks=("homelab-main" "homelab-media" "homelab-mgmt" "homelab-db")
+for network in "${networks[@]}"; do
+    if docker network ls | grep -q "$network"; then
+        print_success "Network $network exists"
+    else
+        print_warning "Network $network not found (will be created)"
+    fi
+done
+
+# Test 10: Check file permissions
+print_status "Test 10: Checking file permissions..."
+if [ -f "/Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json" ]; then
+    perms=$(stat -f "%OLp" /Volumes/WorkDrive/MacStorage/docker/traefik/certificates/acme.json 2>/dev/null || echo "unknown")
+    if [ "$perms" = "600" ]; then
+        print_success "acme.json has correct permissions (600)"
+    else
+        print_warning "acme.json permissions: $perms (should be 600)"
+    fi
+else
+    print_warning "acme.json not found (will be created)"
+fi
+
+echo ""
+print_success "Setup test completed!"
+echo ""
+echo "Next steps:"
+echo "1. If .env file is missing or incomplete, edit it with your values"
+echo "2. Run: ./deploy-mac-homelab.sh"
+echo "3. Configure router port forwarding (80, 443 → Mac IP)"
+echo "4. Configure Cloudflare DNS (DNS only, not proxied)"
+echo "5. Test: ./health-check-mac.sh"
+echo ""
+echo "Your Mac IP for router configuration: $mac_ip_wifi"

--- a/traefik/config/dynamic-mac.yml
+++ b/traefik/config/dynamic-mac.yml
@@ -1,0 +1,81 @@
+# Dynamic Traefik Configuration for Mac Homelab
+# This file contains middleware and additional configuration
+
+http:
+  middlewares:
+    # Security headers
+    secure-headers:
+      headers:
+        frameDeny: true
+        contentTypeNosniff: true
+        browserXssFilter: true
+        referrerPolicy: "strict-origin-when-cross-origin"
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"
+        customResponseHeaders:
+          X-Robots-Tag: "noindex,nofollow,nosnippet,noarchive"
+          X-Content-Type-Options: "nosniff"
+          X-Frame-Options: "DENY"
+          X-XSS-Protection: "1; mode=block"
+          Strict-Transport-Security: "max-age=31536000; includeSubDomains"
+          Referrer-Policy: "strict-origin-when-cross-origin"
+          Permissions-Policy: "camera=(), microphone=(), geolocation=()"
+
+    # Authelia authentication
+    authelia:
+      forwardAuth:
+        address: "http://authelia:9091/api/verify?rd=https://auth.mbs-home.ddns.net/"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - "Remote-User"
+          - "Remote-Groups"
+          - "Remote-Name"
+          - "Remote-Email"
+
+    # Nextcloud specific headers
+    nextcloud-headers:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"
+          X-Forwarded-Ssl: "on"
+          X-Forwarded-Host: "nextcloud.mbs-home.ddns.net"
+        customResponseHeaders:
+          Referrer-Policy: "no-referrer"
+
+    # Jellyfin specific headers for mobile compatibility
+    jellyfin-headers:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"
+          X-Forwarded-Host: "media.mbs-home.ddns.net"
+          X-Forwarded-For: "$$remote_addr"
+
+    # Rate limiting
+    rate-limit:
+      rateLimit:
+        burst: 100
+        average: 50
+
+    # IP whitelist for admin services
+    admin-whitelist:
+      ipWhiteList:
+        sourceRange:
+          - "127.0.0.1/32"
+          - "192.168.1.0/24"
+          - "10.0.0.0/8"
+          - "172.16.0.0/12"
+
+# TLS configuration
+tls:
+  options:
+    default:
+      sslProtocols:
+        - "TLSv1.2"
+        - "TLSv1.3"
+      cipherSuites:
+        - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+        - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        - "TLS_RSA_WITH_AES_256_GCM_SHA384"
+        - "TLS_RSA_WITH_CHACHA20_POLY1305"
+        - "TLS_RSA_WITH_AES_128_GCM_SHA256"

--- a/traefik/config/traefik-mac.yml
+++ b/traefik/config/traefik-mac.yml
@@ -1,0 +1,68 @@
+# Traefik Configuration for Mac with External Drive
+# This configuration is optimized for macOS with Docker Desktop
+
+api:
+  dashboard: true
+  debug: true
+
+entryPoints:
+  http:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: https
+          scheme: https
+          permanent: true
+  https:
+    address: ":443"
+
+serversTransport:
+  insecureSkipVerify: true
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: homelab-main
+  file:
+    filename: /etc/traefik/dynamic.yml
+    watch: true
+
+certificatesResolvers:
+  cloudflare:
+    acme:
+      email: ${CF_API_EMAIL}
+      storage: /certificates/acme.json
+      caServer: https://acme-v02.api.letsencrypt.org/directory
+      dnsChallenge:
+        provider: cloudflare
+        delayBeforeCheck: 0
+        resolvers:
+          - "1.1.1.1:53"
+          - "1.0.0.1:53"
+
+# Fallback to HTTP challenge if Cloudflare fails
+  letsencrypt:
+    acme:
+      httpChallenge:
+        entryPoint: http
+      email: ${CF_API_EMAIL}
+      storage: /certificates/acme.json
+
+log:
+  level: INFO
+  format: common
+
+accessLog:
+  format: common
+
+metrics:
+  prometheus:
+    addEntryPointsLabels: true
+    addServicesLabels: true
+    buckets:
+      - 0.1
+      - 0.3
+      - 1.2
+      - 5.0


### PR DESCRIPTION
Implement a comprehensive fix for Mac homelab external drive setup to resolve 404 errors and enable HTTPS access for all services.

The previous setup on macOS with Docker Desktop and an external drive resulted in services being inaccessible (404 errors) due to misconfigured Docker Desktop file sharing, incorrect file permissions on critical Traefik files (like `acme.json`), and sub-optimal Traefik and network configurations. This PR provides a complete, Mac-optimized solution including new `docker-compose-mac.yml`, Traefik configs, and helper scripts to ensure proper external drive integration, SSL certificate management, and service accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-51bc1335-1831-4032-9653-611604979782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51bc1335-1831-4032-9653-611604979782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

